### PR TITLE
Update Hash.java

### DIFF
--- a/src/main/java/com/github/kilianB/hash/Hash.java
+++ b/src/main/java/com/github/kilianB/hash/Hash.java
@@ -436,7 +436,7 @@ public class Hash implements Serializable {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!(obj instanceof Hash))
 			return false;
 		Hash other = (Hash) obj;
 		if (algorithmId != other.getAlgorithmId())


### PR DESCRIPTION
Changed on equals method to use "instanceof" to check the 2 objects class instead of "obj.getClass()".
This is for when you create a hash using bigInteger contructor which create a Hash object, while if create a hash from an image, the object will be of the hash algorithm type you have chosen, and the equals will return false while the 2 are in fact equals.