### PR TITLE
remove javafx

### DIFF
--- a/src/main/java/dev/brachtendorf/jimagehash/hash/FuzzyHash.java
+++ b/src/main/java/dev/brachtendorf/jimagehash/hash/FuzzyHash.java
@@ -1,5 +1,6 @@
 package dev.brachtendorf.jimagehash.hash;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -12,7 +13,6 @@ import java.util.logging.Logger;
 
 import dev.brachtendorf.graphics.ColorUtil;
 import dev.brachtendorf.jimagehash.hashAlgorithms.HashingAlgorithm;
-import javafx.scene.paint.Color;
 
 /**
  * A fuzzy hash is an aggregation of multiple hashes mapped to a single mean
@@ -818,8 +818,8 @@ public class FuzzyHash extends Hash {
 		ensureUpToDateHash();
 
 		// Build color palette
-		Color[] lowerCol = ColorUtil.ColorPalette.getPalette(15, Color.web("#ff642b"), Color.web("#ffff7c"));
-		Color[] higherCol = ColorUtil.ColorPalette.getPalette(15, Color.web("#ffff7c"), Color.GREEN);
+		Color[] lowerCol = ColorUtil.ColorPalette.getPalette(15, Color.decode("#ff642b"), Color.decode("#ffff7c"));
+		Color[] higherCol = ColorUtil.ColorPalette.getPalette(15, Color.decode("#ffff7c"), Color.GREEN);
 
 		Color[] colors = new Color[lowerCol.length + higherCol.length];
 		System.arraycopy(lowerCol, 0, colors, 0, lowerCol.length);
@@ -841,8 +841,8 @@ public class FuzzyHash extends Hash {
 		ensureUpToDateHash();
 
 		// Build color palette
-		Color[] lowerCol = ColorUtil.ColorPalette.getPalette(15, Color.web("#ff642b"), Color.web("#ffff7c"));
-		Color[] higherCol = ColorUtil.ColorPalette.getPalette(15, Color.web("#ffff7c"), Color.GREEN);
+		Color[] lowerCol = ColorUtil.ColorPalette.getPalette(15, Color.decode("#ff642b"), Color.decode("#ffff7c"));
+		Color[] higherCol = ColorUtil.ColorPalette.getPalette(15, Color.decode("#ffff7c"), Color.GREEN);
 
 		Color[] colors = new Color[lowerCol.length + higherCol.length];
 		System.arraycopy(lowerCol, 0, colors, 0, lowerCol.length);

--- a/src/main/java/dev/brachtendorf/jimagehash/hash/Hash.java
+++ b/src/main/java/dev/brachtendorf/jimagehash/hash/Hash.java
@@ -1,5 +1,6 @@
 package dev.brachtendorf.jimagehash.hash;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -14,7 +15,6 @@ import dev.brachtendorf.Require;
 import dev.brachtendorf.StringUtil;
 import dev.brachtendorf.graphics.FastPixel;
 import dev.brachtendorf.jimagehash.hashAlgorithms.HashingAlgorithm;
-import javafx.scene.paint.Color;
 
 /**
  * Hashes are bit encoded encoded values (0101011101) created from images using

--- a/src/main/java/dev/brachtendorf/jimagehash/hashAlgorithms/DifferenceHash.java
+++ b/src/main/java/dev/brachtendorf/jimagehash/hashAlgorithms/DifferenceHash.java
@@ -1,5 +1,6 @@
 package dev.brachtendorf.jimagehash.hashAlgorithms;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.math.BigInteger;
 import java.util.Objects;
@@ -7,7 +8,6 @@ import java.util.Objects;
 
 import dev.brachtendorf.graphics.FastPixel;
 import dev.brachtendorf.jimagehash.hash.Hash;
-import javafx.scene.paint.Color;
 
 /**
  * Calculates a hash based on gradient tracking. This hash is cheap to compute

--- a/src/main/java/dev/brachtendorf/jimagehash/hashAlgorithms/HashingAlgorithm.java
+++ b/src/main/java/dev/brachtendorf/jimagehash/hashAlgorithms/HashingAlgorithm.java
@@ -307,7 +307,7 @@ public abstract class HashingAlgorithm implements Serializable {
 			 */
 			if (this.opaqueReplacementColor == null) {
 
-				javafx.scene.paint.Color interpolatedColor = ImageUtil.interpolateColor(image);
+				Color interpolatedColor = ImageUtil.interpolateColor(image);
 				Color replacementColor = ColorUtil.getContrastColor(ColorUtil.fxToAwtColor(interpolatedColor));
 				fp.setReplaceOpaqueColors(this.opaqueReplacementThreshold, replacementColor);
 			} else {


### PR DESCRIPTION
Javafx is a dependency burden which can be dropped, so JImageHash can be lighter

> And project `UtilityCode`